### PR TITLE
Allow single filters like populate

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ $response = FootballApi::fixtures()
 // API call for Fixtures with deleted filter
 $response = FootballApi::fixtures()
     ->setFilters(['deleted'])
-    ->getAll();
+    ->all();
 ```
 ##### Populate filter
 ```php
 // API call for Fixtures with populate (1000 per page)
 $response = FootballApi::fixtures()
     ->setFilters(['populate'])
-    ->getAll();
+    ->all();
 ```
 
 Note: This client will not validate the usage for the correct endpoints and will not throw an error. Refer to the

--- a/README.md
+++ b/README.md
@@ -82,13 +82,31 @@ $response = FootballApi::fixtures()
 ```
 
 ### Filtering
-// API call for Fixtures with filters
+
+##### Entity filter
 ```php
+// API call for Fixtures with filters
 $response = FootballApi::fixtures()
     ->setInclude(['events','statistics.type'])
     ->setFilters(['eventTypes' => [18,14]])
     ->getByDate('2023-03-19');
 ```
+
+##### Deleted filter
+```php
+// API call for Fixtures with deleted filter
+$response = FootballApi::fixtures()
+    ->setFilters(['deleted'])
+    ->getAll();
+```
+##### Populate filter
+```php
+// API call for Fixtures with populate (1000 per page)
+$response = FootballApi::fixtures()
+    ->setFilters(['populate'])
+    ->getAll();
+```
+
 Note: This client will not validate the usage for the correct endpoints and will not throw an error. Refer to the
 [Sportmonks docs](https://docs.sportmonks.com/football/endpoints-and-entities/endpoints) to see which endpoints support the above parameters.
 

--- a/src/FootballClient.php
+++ b/src/FootballClient.php
@@ -83,7 +83,7 @@ class FootballClient {
 		foreach ($filters as $filterName => $filterVars) {
 			if (is_array($filterVars)) {
 				$filter[] = $filterName . ':' . implode(",", array_map("trim", array_filter($filterVars)));
-			} elseif ($filterVars == 'deleted') {
+			} else {
 				$filter[] = $filterVars;
 			}
 		}


### PR DESCRIPTION
The current implementation for setFilters() only allows for 'deleted' filter, while there is other filters like 'populate'.
This pull request solve this issue.