### PR TITLE
PHP Support fixes & Dependency update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^7.3 | ^8",
-    "symfony/http-client": "^5.4.31"
+    "symfony/http-client": "^5.4.41"
   },
   "autoload": {
     "psr-4": {

--- a/src/FootballApiHelper.php
+++ b/src/FootballApiHelper.php
@@ -9,8 +9,7 @@ use Sportmonks\Football\Exception\InvalidDateFormatException;
  * Class FootballApiHelper
  * @package Sportmonks\Football
  */
-class FootballApiHelper
-{
+class FootballApiHelper {
     /**
      * @param string $date
      * @param string $format
@@ -22,7 +21,10 @@ class FootballApiHelper
         $dateTime = DateTime::createFromFormat($format, $date);
 
         // Check for errors
-        $dateTimeErrors = DateTime::getLastErrors();
+        $dateTimeErrors = DateTime::getLastErrors() ?: [
+            'warning_count' => 0,
+            'error_count' => 0
+        ];
 
         // Validate DateTime
         if (!$dateTime || ($dateTimeErrors['warning_count'] + $dateTimeErrors['error_count']) > 0) {


### PR DESCRIPTION
- Fix: PHP 8.2+ DateTime::getLastErrors() may return false
- Update symfony/http-client requirement to ^5.4.41
- Tested up to php 8.4